### PR TITLE
Make leader channel recover from a nil value.

### DIFF
--- a/client.go
+++ b/client.go
@@ -227,7 +227,7 @@ func (s *serviceSet) Leaders() chan *Service {
 		leader := s.Leader()
 		leaders <- leader
 		for update := range updates {
-			if !update.Online && update.Addr == leader.Addr {
+			if (!update.Online && update.Addr == leader.Addr) || (update.Online && leader == nil) {
 				leader = s.Leader()
 				leaders <- leader
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -411,14 +411,18 @@ func TestLeaderChannel(t *testing.T) {
 		}
 	}()
 
-	assert(client.Register(serviceName, ":2222"), t)
-
 	if (<-leader).Addr != "127.0.0.1:1111" {
 		t.Fatal("Incorrect leader")
 	}
 
-	assert(client.Register(serviceName, ":3333"), t)
 	assert(client.Unregister(serviceName, ":1111"), t)
+
+	if (<-leader) != nil {
+		t.Fatal("Incorrect leader")
+	}
+
+	assert(client.Register(serviceName, ":2222"), t)
+	assert(client.Register(serviceName, ":3333"), t)
 
 	if (<-leader).Addr != "127.0.0.1:2222" {
 		t.Fatal("Incorrect leader", leader)


### PR DESCRIPTION
Before, if there is no leader at the beginning, or the leader disappears, the leader channel will never provide an update.

This will be required for sdutil expose.
