### PR TITLE
Add balancer to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
   - DEBUG=1
 
 script:
-  - godep go test -race
-  - godep go test -cover
+  - godep go test ./... -race
+  - godep go test ./... -cover
 
 notifications:
   irc:


### PR DESCRIPTION
adds the balancer package to the go test command - was being ignored before
