### PR TITLE
Test packages separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ env:
   - DEBUG=1
 
 script:
-  - godep go test ./... -race
-  - godep go test ./... -cover
+  - godep go test -race
+  - godep go test ./balancer -race
+  - godep go test -cover
+  - godep go test ./balancer -cover
 
 notifications:
   irc:


### PR DESCRIPTION
When running go test against more than one package using
a wildcard operator, the output of the test command will
be withheld until the end of the test run.

Travis is currently hanging consistently on some builds
of go-discoverd and using a wildcard operator in go test
results in a dearth of debugging info. This splits the
travis tests into one per package to make debugging easier.

Signed-off-by: Anthony Bishopric git@anthonybishopric.com
