### PR TITLE
Fix intermittent TestFiltering test

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -323,7 +323,7 @@ func TestFiltering(t *testing.T) {
 	}
 
 	assert(client.RegisterWithAttributes(serviceName, ":3333", map[string]string{"foo": "qux", "id": "3"}), t)
-	waitUpdates(t, watchSet, true, 3)()
+	waitUpdates(t, set, true, 2)()
 	if s := set.Services(); len(s) < 2 {
 		t.Fatalf("Filter not letting new matching services in set: %#v", s[0])
 	}


### PR DESCRIPTION
This fixes a race condition where the `watchSet` has received the discoverd update but the filtered set hasn't, leading to `set.Services()` only returning one service and the test failing.
