### PR TITLE
Don't create a client if there is a connection error

### DIFF
--- a/client.go
+++ b/client.go
@@ -449,7 +449,10 @@ func NewClient() (*Client, error) {
 
 func NewClientWithAddr(addr string) (*Client, error) {
 	c, err := rpcplus.DialHTTP("tcp", addr)
-	return newClient(c, addr), err
+	if err != nil {
+		return nil, err
+	}
+	return newClient(c, addr), nil
 }
 
 func NewClientWithRPCClient(c *rpcplus.Client) *Client {


### PR DESCRIPTION
This means `DefaultClient` will remain nil if calling `discoverd.Connect()` leads to a connection error.
